### PR TITLE
Optimize timestamp filters for transactions

### DIFF
--- a/idb/postgres/postgres.go
+++ b/idb/postgres/postgres.go
@@ -576,13 +576,13 @@ func buildTransactionQuery(tf idb.TransactionFilter) (query string, whereArgs []
 	}
 	if !tf.BeforeTime.IsZero() {
 		convertedTime := tf.BeforeTime.In(time.UTC)
-		whereParts = append(whereParts, fmt.Sprintf("h.realtime < $%d", partNumber))
+		whereParts = append(whereParts, fmt.Sprintf("t.round <= (SELECT bh.round FROM block_header bh WHERE bh.realtime < $%d ORDER BY bh.realtime DESC, bh.round DESC LIMIT 1)", partNumber))
 		whereArgs = append(whereArgs, convertedTime)
 		partNumber++
 	}
 	if !tf.AfterTime.IsZero() {
 		convertedTime := tf.AfterTime.In(time.UTC)
-		whereParts = append(whereParts, fmt.Sprintf("h.realtime > $%d", partNumber))
+		whereParts = append(whereParts, fmt.Sprintf("t.round >= (SELECT bh.round FROM block_header bh WHERE bh.realtime > $%d ORDER BY bh.realtime ASC, bh.round ASC LIMIT 1)", partNumber))
 		whereArgs = append(whereArgs, convertedTime)
 		partNumber++
 	}


### PR DESCRIPTION
## Summary

This pull requests optimizes the filters `after-time` and `before-time` in the `GET /v2/transactions` endpoint.

The rationale behind this optimization is to convert timestamps into rounds (since transactions have lookup indexes based in their round number). This hopefully will avoid an inefficient query execution plan.

## Test Plan

Tested in a local environment with a CRDB light indexer. The resulting execution plan seems to be more efficient, but the amount of data in a light indexer is too small to see a performance improvement.

This change would need to be tested in a full indexer (i.e. full history) to verify that CRDB is picking the right query execution plan.
